### PR TITLE
✨ feat (Options): context, append and support for multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,38 @@ steps:
           volumes:
             - "./output:/app/output"
       - phcyso/annotate-from-file#v1.0.0:
-          path: './output/output.md'
+          path: "./output/output.md"
 ```
 
 ## Configuration
 
 ### `path` (Required, string)
 
-The path to the file to show as an annotation.
+The path to the file to show as an annotation. Each files that match this
+pattern will create an annotation.
 
 ### `must_exist` (Optional, boolean, default: false)
 
-If `must_exist` is set to true then the plugin will exit non zero if the files given in `path` does not exist
+If `must_exist` is set to true then the plugin will exit non zero if the files
+given in `path` does not exist
 
 ### `style` (Optional, string, default: "info")
 
-One of the allowed annotation [styles](https://buildkite.com/docs/agent/v3/cli-annotate#annotation-styles)
+One of the allowed annotation
+[styles](https://buildkite.com/docs/agent/v3/cli-annotate#annotation-styles)
 
+### `context` (Optional, string, default: it will use the default context)
+
+The context of the annotation used to differentiate this annotation from others,
+if no defined it will use default context.
+
+Use `file_name`as context value if you want to specify context value same as
+file name.
+
+### `append` (Optional, boolean, default: false)
+
+Append to the body of an existing annotation depending on the given annotation
+context.
 
 ## Developing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   lint:
     image: buildkite/plugin-linter
-    command: ['--id', 'phcyso/annotate-from-file']
+    command: ["--id", "phcyso/annotate-from-file"]
     volumes:
       - ".:/plugin:ro"
   tests:
     image: buildkite/plugin-tester
     volumes:
-      - ".:/plugin:ro"
+      - ".:/plugin"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,8 +10,7 @@ APPEND="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND:-"false"}"
 
 echo "--- :spiral_note_pad: Annotating build from file"
 
-# if [ ! -e "${FILE_PATH}*" ]; then
-if find . -name "${FILE_PATH}*" -print -quit | grep -q .; then
+if find "$(dirname $FILE_PATH)" -name "$(basename $FILE_PATH)*"; then
   echo "Annotation file exists, continuing"
 else
   echo "Annotation file does not exist, Exiting"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -9,9 +9,7 @@ APPEND="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND:-"false"}"
 
 
 echo "--- :spiral_note_pad: Annotating build from file"
-
-# FILE_PATH="NOFILE"; find "$(dirname $FILE_PATH)" -name "$(basename $FILE_PATH)*"
-
+echo "FILE_PATH:$FILE_PATH"
 
 if find "$(dirname $FILE_PATH)" -name "$(basename $FILE_PATH)*" -print -quit | grep .; then
   echo "Annotation file exists, continuing"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,22 +1,45 @@
 #!/bin/bash
-set -euo pipefail
+# set -euo pipefail
 
 FILE_PATH="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH}"
 STYLE="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE:-"info"}"
 MUST_EXIST="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_MUST_EXIST:-"false"}"
+CONTEXT="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_CONTEXT:-""}"
+APPEND="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND:-"false"}"
+
 
 echo "--- :spiral_note_pad: Annotating build from file"
 
-if [ ! -e "${FILE_PATH}" ]; then 
+# if [ ! -e "${FILE_PATH}*" ]; then
+if find . -name "${FILE_PATH}*" -print -quit | grep -q .; then
+  echo "Annotation file exists, continuing"
+else
   echo "Annotation file does not exist, Exiting"
-  if [ "${MUST_EXIST}" == "true" ]; then 
-    exit 1
-  fi
-  exit 0
+  [ "${MUST_EXIST}" == "true" ] && exit 1 || exit 0
 fi
 
-# TODO Verify the styles
+# Check style values https://buildkite.com/docs/agent/v3/cli-annotate#style
+if [[ ! $STYLE =~ ^(success|info|warning|error)$ ]]; then
+  echo "'$STYLE' is a non valid style."
+  exit 1
+fi
+[[ "$APPEND" == "true" ]] && APPEND_FLAG="--append" || APPEND_FLAG=""
+[[ -n "$CONTEXT" ]] && CONTEXT_FLAG="--context $CONTEXT" || CONTEXT_FLAG=""
 
-# TODO Allow for appending to existing annotations using contexts
+echo "FILE_PATH: $FILE_PATH"
+echo "STYLE: $STYLE"
+echo "MUST_EXIST: $MUST_EXIST"
+echo "CONTEXT_FLAG: $CONTEXT_FLAG"
+echo "APPEND_FLAG: $APPEND_FLAG"
 
-cat "${FILE_PATH}" | buildkite-agent annotate --style "${STYLE}"
+# Use find to search for all files that match the pattern specified by FILE_PATH
+ANNOTATION_COUNTER=0
+
+find "$(dirname $FILE_PATH)" -name "$(basename $FILE_PATH)*" -type f | while read -r file; do
+  ((ANNOTATION_COUNTER++))
+  [[ "$CONTEXT" == "file_name" ]] && CONTEXT_FLAG="--context $(basename $file)"
+  cat "$file" | buildkite-agent annotate --style "$STYLE" $CONTEXT_FLAG $APPEND_FLAG
+  echo "$ANNOTATION_COUNTER Annotation created for $FILE_PATH file $CONTEXT_FLAG"
+done
+
+echo "Annotation created - Done"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,7 +10,10 @@ APPEND="${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND:-"false"}"
 
 echo "--- :spiral_note_pad: Annotating build from file"
 
-if find "$(dirname $FILE_PATH)" -name "$(basename $FILE_PATH)*"; then
+# FILE_PATH="NOFILE"; find "$(dirname $FILE_PATH)" -name "$(basename $FILE_PATH)*"
+
+
+if find "$(dirname $FILE_PATH)" -name "$(basename $FILE_PATH)*" -print -quit | grep .; then
   echo "Annotation file exists, continuing"
 else
   echo "Annotation file does not exist, Exiting"

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,9 +5,13 @@ requirements: []
 configuration:
   properties:
     path:
-      type: string   
+      type: string
     style:
-      type: string     
+      type: string
     must_exist:
+      type: boolean
+    context:
+      type: string
+    append:
       type: boolean
   additionalProperties: false

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,24 +1,27 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
 
-# Uncomment the following line to debug stub failures
-export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
+
+  # Uncomment the following line to debug stub failures
+  # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+}
 
 @test "Creates an annotation from a given file" {
   export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="test_file.test"
 
   echo "hello world" >> test_file.test
 
-  stub buildkite-agent 'annotate "--style \"info\"" : echo Annotation created'
+  stub buildkite-agent 'annotate --style "info" : echo Annotation created'
 
   run "$PWD/hooks/post-command"
 
-  assert_success
-  assert_output --partial "Annotation created"
-
   unstub buildkite-agent
   rm test_file.test
+
+  assert_output --partial "Annotation created"
+  assert_success
 }
 
 @test "Exits cleanly when file doesnt exist " {
@@ -26,18 +29,134 @@ export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
    run "$PWD/hooks/post-command"
 
-   assert_success
    assert_output --partial "Annotation file does not exist, Exiting"
-
+   assert_success
 }
 
 @test "Exits with 1 when file doesnt exist and must_exist is true " {
-  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="*.bats"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="*999.bats"
   export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_MUST_EXIST="true"
 
   run "$PWD/hooks/post-command"
 
-  assert_failure
   assert_output --partial "Annotation file does not exist, Exiting"
+  assert_failure
+}
 
+@test "Valid case with append and context" {
+  test_file="test_file_context.test"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="${test_file}"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE=success
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_MUST_EXIST=false
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_CONTEXT=test-context
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND=true
+
+  echo "hello world" >> $test_file
+
+  stub buildkite-agent 'annotate --style "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE" --context "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_CONTEXT" --append : echo Annotation created'
+
+  run "$PWD/hooks/post-command"
+
+  unstub buildkite-agent
+  rm "$test_file"
+
+  assert_output --partial "Annotation created"
+  assert_success
+}
+
+@test "Invalid style case" {
+  test_file="test_file_context.test"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="${test_file}"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE=invalid_style
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_MUST_EXIST=false
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_CONTEXT=test-context
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND=false
+
+  echo "hello world" >> $test_file
+
+  run "$PWD/hooks/post-command"
+  rm "$test_file"
+
+  assert_output --partial "is a non valid style"
+  assert_failure
+}
+
+@test "Annotation Append without context " {
+  test_file="test_file_append.test"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="${test_file}"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE=info
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_MUST_EXIST=false
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_CONTEXT=""
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND=true
+
+  echo "hello world" >> $test_file
+  stub buildkite-agent 'annotate --style "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE" --append : echo Annotation created'
+
+  run "$PWD/hooks/post-command"
+
+  unstub buildkite-agent
+  rm "$test_file"
+
+  assert_output --partial "Annotation created"
+  assert_success
+}
+
+@test "Annotation Append with 'file_name' as context' " {
+  test_file="test_file_context_file_name.test"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="${test_file}"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE=info
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_MUST_EXIST=false
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_CONTEXT="file_name"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND=true
+
+  echo "hello world" >> $test_file
+  echo "hello world" >> "diff_${test_file}_asdfa.txt"
+  stub buildkite-agent 'annotate --style "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE" --context "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH" --append : echo Annotation created with context $BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH'
+
+  run "$PWD/hooks/post-command"
+
+  unstub buildkite-agent
+  rm "$test_file"
+  rm "diff_${test_file}_asdfa.txt"
+
+  assert_output --partial "Annotation created with context $BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH"
+  assert_success
+}
+
+@test "Multiple files: Annotation Append with 'file_name' as context' " {
+  test_file="test_file_context_file_name.test"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="${test_file}"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE=info
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_MUST_EXIST=false
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_CONTEXT="file_name"
+  export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_APPEND=true
+
+  echo "hello world" >> "${test_file}_1.txt"
+  echo "hello world" >> "${test_file}_2.txt"
+  echo "hello world" >> "${test_file}_3.txt"
+  echo "hello world" >> "${test_file}_4.txt"
+  echo "hello world" >> "Not_include_${test_file}_5.txt"
+
+  stub buildkite-agent 'annotate --style "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE" --context "${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH}_1.txt" --append : echo Annotation created'
+  stub buildkite-agent 'annotate --style "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE" --context "${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH}_2.txt" --append : echo Annotation created'
+  stub buildkite-agent 'annotate --style "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE" --context "${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH}_3.txt" --append : echo Annotation created'
+  stub buildkite-agent 'annotate --style "$BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_STYLE" --context "${BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH}_4.txt" --append : echo Annotation created'
+
+  run "$PWD/hooks/post-command"
+
+  unstub buildkite-agent
+
+  rm "${test_file}_1.txt"
+  rm "${test_file}_2.txt"
+  rm "${test_file}_3.txt"
+  rm "${test_file}_4.txt"
+  rm "Not_include_${test_file}_5.txt"
+
+  assert_output --partial "1 Annotation created for"
+  assert_output --partial "2 Annotation created for"
+  assert_output --partial "3 Annotation created for"
+  assert_output --partial "4 Annotation created for"
+  refute_output "Not_include_"
+  assert_output --partial "Annotation created - Done"
+  assert_success
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -27,10 +27,10 @@ setup() {
 @test "Exits cleanly when file doesnt exist " {
   export BUILDKITE_PLUGIN_ANNOTATE_FROM_FILE_PATH="NOFILE"
 
-   run "$PWD/hooks/post-command"
+  run "$PWD/hooks/post-command"
 
-   assert_output --partial "Annotation file does not exist, Exiting"
-   assert_success
+  assert_output --partial "Annotation file does not exist, Exiting"
+  assert_success
 }
 
 @test "Exits with 1 when file doesnt exist and must_exist is true " {


### PR DESCRIPTION
“Annotate From File Buildkite Plugin: This pull request #2 enhances the plugin by adding support for multiple files. Specifically, it creates annotations for each file specified by the provided path. Now, users can benefit from detailed annotations associated with relevant files in their builds.”
**Detailed Annotations:** By creating annotations per file, the plugin provides granular information about test failures or any kind of annotation that it will be needed. Users can quickly identify which specific files or test suites encountered issues.

![image](https://github.com/phcyso/annotate-from-file-buildkite-plugin/assets/58176975/559604b8-1dd2-41ae-8aac-56922cc27cfa)
